### PR TITLE
add pluralize and singularize funcs

### DIFF
--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/basemachina/xo/models"
+	"github.com/gedex/inflector"
 	"github.com/kenshaw/snaker"
 )
 
@@ -39,6 +40,8 @@ func (a *ArgType) NewTemplateFuncs() template.FuncMap {
 		"hascolumn":          a.hascolumn,
 		"hasfield":           a.hasfield,
 		"getstartcount":      a.getstartcount,
+		"pluralize":          a.pluralize,
+		"singularize":        a.singularize,
 	}
 	for k, v := range tmp {
 		fkmap[k] = v
@@ -750,4 +753,14 @@ func (a *ArgType) hasfield(fields []*Field, name string) bool {
 // getstartcount returns a starting count for numbering columsn in queries
 func (a *ArgType) getstartcount(fields []*Field, pkFields []*Field) int {
 	return len(fields) - len(pkFields)
+}
+
+// pluralize returns string s in plural form.
+func (a *ArgType) pluralize(s string) string {
+	return inflector.Pluralize(s)
+}
+
+// singularize returns string s in singular form.
+func (a *ArgType) singularize(s string) string {
+	return inflector.Singularize(s)
 }


### PR DESCRIPTION
* Add plurarize and singularize funcs.
  - These logics are used in xo.
    - https://github.com/basemachina/xo/blob/6fe83c5f98b30a0e357cbb37b7a604c60be00f66/internal/util.go#L217
    - https://github.com/basemachina/xo/blob/91e43fb740892815368481ec090c73a0123b3974/internal/loader.go#L213
* These funcs are required to use complex pluralize / singularize rules.
  - Sprig already has [plural](https://masterminds.github.io/sprig/strings.html#plural) func, but this func supports only simple usecases (was not enough for my usecases).